### PR TITLE
Hack to work with td-agent 2.3.0

### DIFF
--- a/lib/fluent/plugin/in_prometheus_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_monitor.rb
@@ -19,7 +19,8 @@ module Fluent
       super
       hostname = Socket.gethostname
       expander = Fluent::Prometheus.placeholder_expander(log)
-      placeholders = expander.prepare_placeholders({'hostname' => hostname})
+      placeholders = expander.prepare_placeholders(
+        Time.now, {'hostname' => hostname}, [])
       @base_labels = Fluent::Prometheus.parse_labels_elements(conf)
       @base_labels.each do |key, value|
         @base_labels[key] = expander.expand(value, placeholders)


### PR DESCRIPTION
Hi there - looks like something has changed in the API, but it means that the prometheus_monitor plugin can't start against td-agent v2.3.0. I'm afraid I'm not much of a Ruby coder so I haven't done anything more sophisticated than change the arguments. I'm happy to do more work to get this merged if you can give me guidance of how to go about it.