### PR TITLE
Fix monitor agent class

### DIFF
--- a/lib/fluent/plugin/in_prometheus_monitor.rb
+++ b/lib/fluent/plugin/in_prometheus_monitor.rb
@@ -25,7 +25,12 @@ module Fluent
         @base_labels[key] = expander.expand(value, placeholders)
       end
 
-      @monitor_agent = Fluent::MonitorAgentInput.new
+      if defined?(Fluent::Plugin) && defined?(Fluent::Plugin::MonitorAgentInput)
+        # from v0.14.6
+        @monitor_agent = Fluent::Plugin::MonitorAgentInput.new
+      else
+        @monitor_agent = Fluent::MonitorAgentInput.new
+      end
 
       buffer_queue_length = @registry.gauge(
         :fluentd_status_buffer_queue_length,

--- a/misc/fluentd_sample.conf
+++ b/misc/fluentd_sample.conf
@@ -58,6 +58,9 @@
   #   @id test_forward
   #   @type forward
   #   buffer_type memory
+  #   flush_interval 1s
+  #   max_retry_wait 1s
+  #   disable_retry_limit
   #  <server>
   #    host 127.0.0.1
   #    port 20000


### PR DESCRIPTION
`MonitorAgentInput` moved from `Fluent` module into `Fluent::Plugin` module. This fixes to the use class for prometheus_monitor.
Fixes #10