### PR TITLE
Drop support of v0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ rvm:
 gemfile:
   - Gemfile
   - Gemfile.fluentd.0.12
-  - Gemfile.fluentd.0.10
-
-matrix:
-  allow_failures:
-    - gemfile: Gemfile.fluentd.0.10
-      rvm: 2.4.0
 
 script:
   - bundle exec rake spec

--- a/Gemfile.fluentd.0.10
+++ b/Gemfile.fluentd.0.10
@@ -1,4 +1,0 @@
-source 'https://rubygems.org/'
-gem 'fluentd', '~> 0.10.0'
-gem 'fluent-plugin-record-reformer'
-gemspec

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 A fluent plugin that instruments metrics from records and exposes them via web interface. Intended to be used together with a [Prometheus server](https://github.com/prometheus/prometheus).
 
-If you are using Fluentd v0.10, you have to explicitly install [fluent-plugin-record-reformer](https://github.com/sonots/fluent-plugin-record-reformer) together. With Fluentd v0.12 or v0.14, there is no additional dependency.
-
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/fluent-plugin-prometheus.gemspec
+++ b/fluent-plugin-prometheus.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd"
+  spec.add_dependency "fluentd", ">= 0.12.0", "< 2"
   spec.add_dependency "prometheus-client"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/lib/fluent/plugin/filter_prometheus.rb
+++ b/lib/fluent/plugin/filter_prometheus.rb
@@ -20,5 +20,5 @@ module Fluent
       instrument(tag, es, @metrics)
       es
     end
-  end if defined?(Filter)
+  end
 end

--- a/lib/fluent/plugin/prometheus.rb
+++ b/lib/fluent/plugin/prometheus.rb
@@ -45,27 +45,16 @@ module Fluent
 
     def self.placeholder_expander(log)
       # Use internal class in order to expand placeholder
-      if defined?(Fluent::Filter) # for v0.12, built-in PlaceholderExpander
-        begin
-          require 'fluent/plugin/filter_record_transformer'
-          if defined?(Fluent::Plugin::RecordTransformerFilter::PlaceholderExpander)
-            # for v0.14
-            return Fluent::Plugin::RecordTransformerFilter::PlaceholderExpander.new(log: log)
-          else
-            # for v0.12
-            return Fluent::RecordTransformerFilter::PlaceholderExpander.new(log: log)
-          end
-        rescue LoadError => e
-          raise ConfigError, "cannot find filter_record_transformer plugin: #{e.message}"
-        end
-      else # for v0.10, use PlaceholderExapander in fluent-plugin-record-reformer plugin
-        begin
-          require 'fluent/plugin/out_record_reformer.rb'
-          return Fluent::RecordReformerOutput::PlaceholderExpander.new(log: log)
-        rescue LoadError => e
-          raise ConfigError, "cannot find fluent-plugin-record-reformer: #{e.message}"
-        end
+      require 'fluent/plugin/filter_record_transformer'
+      if defined?(Fluent::Plugin::RecordTransformerFilter::PlaceholderExpander)
+        # for v0.14
+        return Fluent::Plugin::RecordTransformerFilter::PlaceholderExpander.new(log: log)
+      else
+        # for v0.12
+        return Fluent::RecordTransformerFilter::PlaceholderExpander.new(log: log)
       end
+    rescue LoadError => e
+      raise ConfigError, "cannot find filter_record_transformer plugin: #{e.message}"
     end
 
     def configure(conf)

--- a/spec/fluent/plugin/filter_prometheus_spec.rb
+++ b/spec/fluent/plugin/filter_prometheus_spec.rb
@@ -31,4 +31,4 @@ describe Fluent::PrometheusFilter do
 
     it_behaves_like 'instruments record'
   end
-end if defined?(Fluent::PrometheusFilter)
+end


### PR DESCRIPTION
Fluentd v0.10 is officially annouced as EOL.
https://groups.google.com/forum/#!topic/fluentd/c4f9j9VMWkA