### PR TITLE
reduce MaxClients

### DIFF
--- a/lib/fluent/plugin/in_prometheus.rb
+++ b/lib/fluent/plugin/in_prometheus.rb
@@ -26,6 +26,7 @@ module Fluent
       @server = WEBrick::HTTPServer.new(
         BindAddress: @bind,
         Port: @port,
+        MaxClients: 5,
         Logger: WEBrick::Log.new(STDERR, WEBrick::Log::FATAL),
         AccessLog: [],
       )


### PR DESCRIPTION
The default `MaxClients` is `100`.
https://github.com/ruby/webrick/blob/0ebb2b3fb89077b41d34f798c2304d20d974ca6d/lib/webrick/config.rb#L33

I think the setting is too much for fluent-plugin-prometheus.
How do you think?