### PR TITLE
Modified @type of prometheus_tail_monitor input plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Default labels:
 With following configuration, those metrics are collected.
 
 <source>
-  @type prometheus_output_monitor
+  @type prometheus_tail_monitor
 </source>
 
 More configuration parameters:


### PR DESCRIPTION
Changed the @type of prometheus_tail_monitor plugin in Readme file to prometheus_tail_monitor from prometheus_output_monitor.